### PR TITLE
[fix] Fix the introduction page  and github repo link

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,4 +6,4 @@ src = "src"
 title = "BGCE ARCHIVE"
 
 [output.html]
-git-repository-url = "https://github.com/JsIqbal/bgce-archive"
+git-repository-url = "https://github.com/NesoHQ/bgce-archive.git"

--- a/introduction/README.md
+++ b/introduction/README.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img src="docs/ui/bgce.png" alt="BGCE-ARCHIVE" width="200" style="border-radius: 50%; border: 2px solid #1e90ff; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);" />
-</p>
-
 # 🌐 **Golang Community Vault**
 
 Welcome to **Golang Community Archive**, a community-driven digital archive designed to collect, organize, and preserve the vast knowledge, resources, and experiences from the Go programming ecosystem and beyond. Whether you're a beginner, job seeker, seasoned contributor, or mentor — **this is the place** where we give and receive knowledge.


### PR DESCRIPTION
### 📘 Description

Fix the introduction page by removing the logo and updated the git repo url in book.toml

### 🚀 Changes Made

- Fixed github repo link in book.toml
- Fixed README.md file in introduction chapter 

### ✅ Checklist

- [ ] Follows contribution guidelines
- [ ] Uses correct Markdown format
- [ ] Tested rendering in preview