### PR TITLE
[category] (feat/delete-auth): Implemented role based authorization f…

### DIFF
--- a/cortex/rest/handlers/delete_category_by_id.go
+++ b/cortex/rest/handlers/delete_category_by_id.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"cortex/rest/middlewares"
 	"cortex/rest/utils"
 
 	"github.com/google/uuid"
@@ -15,11 +16,18 @@ func (handlers *Handlers) DeleteCategoryByID(w http.ResponseWriter, r *http.Requ
 		utils.SendError(w, http.StatusBadRequest, "invalid UUID", nil)
 		return
 	}
+
+	if !middlewares.IsAdmin(r) {
+		utils.SendError(w, http.StatusForbidden, "Only admin can delete categories", nil)
+		return
+	}
+
 	if err := handlers.CategoryService.DeleteCategoryByUUID(r.Context(), category_uuid); err != nil {
-		slog.Error("handler: category deletation failed", slog.Any("error", err))
+		slog.Error("handler: category deletion failed", slog.Any("error", err))
 		utils.SendError(w, http.StatusInternalServerError, "failed to delete category", err)
 		return
 	}
+	
 	utils.SendJson(w, http.StatusOK, SuccessResponse{
 		Message: "Category deleted successfully",
 		Status:  http.StatusOK,

--- a/cortex/rest/middlewares/authenticate_jwt.go
+++ b/cortex/rest/middlewares/authenticate_jwt.go
@@ -5,10 +5,9 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"cortex/rest/utils"
 
 	"github.com/golang-jwt/jwt/v5"
-
-	"cortex/rest/utils"
 )
 
 const (
@@ -22,11 +21,15 @@ const (
 	UserIdKey    contextKey = "userId"
 	UserNameKey  contextKey = "userName"
 	UserEmailKey contextKey = "userEmail"
+	UserRoleKey  contextKey = "userRole"
+	IsAdminKey   contextKey = "isAdmin"
 )
 
 type authClaims struct {
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	Name    string `json:"name"`
+	Email   string `json:"email"`
+	Role    string `json:"role"`
+	IsAdmin bool   `json:"is_admin"`
 	jwt.RegisteredClaims
 }
 
@@ -78,6 +81,8 @@ func (m *Middlewares) AuthenticateJWT(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), UserIdKey, userID)
 		ctx = context.WithValue(ctx, UserNameKey, claims.Name)
 		ctx = context.WithValue(ctx, UserEmailKey, claims.Email)
+		ctx = context.WithValue(ctx, UserRoleKey, claims.Role)
+		ctx = context.WithValue(ctx, IsAdminKey, claims.IsAdmin)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
@@ -96,4 +101,14 @@ func GetUserName(r *http.Request) string {
 func GetUserEmail(r *http.Request) string {
 	userEmail, _ := r.Context().Value(UserEmailKey).(string)
 	return userEmail
+}
+
+func GetUserRole(r *http.Request) string {
+	role, _ := r.Context().Value(UserRoleKey).(string)
+	return role
+}
+
+func IsAdmin(r *http.Request) bool {
+	isAdmin, _ := r.Context().Value(IsAdminKey).(bool)
+	return isAdmin
 }

--- a/cortex/rest/server.go
+++ b/cortex/rest/server.go
@@ -18,16 +18,20 @@ func NewServeMux(mw *middlewares.Middlewares, handlers *handlers.Handlers) (*htt
 		// mw.RedisToggle,
 		mw.AuthenticateJWT,
 	))
-	mux.Handle("GET /api/v1/categories",manager.With(http.HandlerFunc(handlers.GetCategoryList)))
+	mux.Handle("GET /api/v1/categories", manager.With(http.HandlerFunc(handlers.GetCategoryList)))
 	mux.Handle("GET /api/v1/categories/{category_uuid}", http.HandlerFunc(handlers.GetCategoryByUUID))
 	mux.Handle("PUT /api/v1/categories/{slug}", manager.With(
 		http.HandlerFunc(handlers.UpdateCategory),
 		// mw.RedisToggle,
 		mw.AuthenticateJWT,
 	))
-	mux.Handle("DELETE /api/v1/categories/{category_id}", http.HandlerFunc(handlers.DeleteCategoryByID))
-	mux.Handle("GET /api/v1/hello", http.HandlerFunc(handlers.Hello))
 
+	mux.Handle("DELETE /api/v1/categories/{category_id}", manager.With(
+		http.HandlerFunc(handlers.DeleteCategoryByID),
+		mw.AuthenticateJWT,
+	))
+
+	mux.Handle("GET /api/v1/hello", http.HandlerFunc(handlers.Hello))
 
 	mux.Handle("POST /api/v1/sub-categories", manager.With(
 		http.HandlerFunc(handlers.CreateSubCategory),

--- a/cortex/util/generate_token.go
+++ b/cortex/util/generate_token.go
@@ -2,20 +2,27 @@ package util
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
-func GenerateToken(secret string, email string) (string, error) {
-	token, err := jwt.NewWithClaims(
-		jwt.SigningMethodHS256,
-		jwt.MapClaims{
-			"Email": email,
-		},
-	).SignedString([]byte(secret))
+func GenerateToken(secret string, userID int, name, email, role string) (string, error) {
+	claims := jwt.MapClaims{
+		"sub":      fmt.Sprintf("%d", userID),
+		"name":     name,
+		"email":    email,
+		"role":     role,
+		"is_admin": role == "admin",
+		"exp":      time.Now().Add(24 * time.Hour).Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	signed, err := token.SignedString([]byte(secret))
 	if err != nil {
 		return "", fmt.Errorf("failed to generate jwt: %w", err)
 	}
 
-	return token, nil
+	return signed, nil
 }

--- a/cortex/util/generate_token_test.go
+++ b/cortex/util/generate_token_test.go
@@ -10,26 +10,44 @@ func TestGenerateToken(t *testing.T) {
 	tests := []struct {
 		name        string
 		secret      string
+		userID      int
+		username    string
 		email       string
+		role        string
 		expectError bool
 	}{
 		{
 			name:        "Valid Token Generation",
 			secret:      "test-secret",
+			userID:      1,
+			username:    "Normal User",
 			email:       "user@example.com",
+			role:        "user",
 			expectError: false,
 		},
 		{
-			name:        "Empty Email - Should Still Generate",
+			name:        "Admin Role Token",
 			secret:      "test-secret",
+			userID:      2,
+			username:    "Admin User",
+			email:       "admin@example.com",
+			role:        "admin",
+			expectError: false,
+		},
+		{
+			name:        "Empty Email - Still Generates",
+			secret:      "test-secret",
+			userID:      3,
+			username:    "NoEmailUser",
 			email:       "",
+			role:        "user",
 			expectError: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			token, err := GenerateToken(tt.secret, tt.email)
+			token, err := GenerateToken(tt.secret, tt.userID, tt.username, tt.email, tt.role)
 
 			if tt.expectError {
 				require.Error(t, err, "expected an error but got none")


### PR DESCRIPTION
📘 Description
Adds role-based JWT authentication to the DELETE /api/v1/categories/{id} endpoint. Only users with the admin role can delete categories. Also updates JWT generation to include role and is_admin claims.

📂 Related Issue
Closes #198

🚀 Changes Made
- Updated handlers.DeleteCategoryByID to enforce admin-only access
- Modified middlewares.AuthenticateJWT to store role and is_admin in the request context
- Added helper function middlewares.IsAdmin(r *http.Request) bool
- Updated util.GenerateToken to include role and is_admin in JWT claims
- Updated tests for token generation and authorization

✅ Checklist
-  Follows contribution guidelines
-  Tested endpoint with admin and non-admin JWT tokens