### PR TITLE
feat(cortex,postal): implement rate limiting middleware to prevent DD…

### DIFF
--- a/cortex/go.mod
+++ b/cortex/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
@@ -72,6 +72,7 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/ulule/limiter/v3 v3.11.2 // indirect
 	go.elastic.co/fastjson v1.1.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/cortex/go.sum
+++ b/cortex/go.sum
@@ -123,6 +123,8 @@ github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xl
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0 h1:c8R11WC8m7KNMkTv/0+Be8vvwo4I3/Ut9AC2FW8fX3U=
@@ -164,6 +166,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/ulule/limiter/v3 v3.11.2 h1:P4yOrxoEMJbOTfRJR2OzjL90oflzYPPmWg+dvwN2tHA=
+github.com/ulule/limiter/v3 v3.11.2/go.mod h1:QG5GnFOCV+k7lrL5Y8kgEeeflPH3+Cviqlqa8SVSQxI=
 github.com/wagslane/go-rabbitmq v0.15.0 h1:KibShYLLeDYc3C5fnx+BjiHJLJdL6D5/BysgcRJknRE=
 github.com/wagslane/go-rabbitmq v0.15.0/go.mod h1:ts7Di9tkLMyI0Z6/aA6T78zQkKDNrtApVis1qqMjqu4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/cortex/rest/middlewares/middleware.go
+++ b/cortex/rest/middlewares/middleware.go
@@ -2,18 +2,25 @@ package middlewares
 
 import (
 	"cortex/config"
+	"github.com/ulule/limiter/v3"
 )
 
 type Middlewares struct {
 	Cnf            *config.Config
 	cache          Cache
 	cortexSettings CortexConfig
+	IPStore        limiter.Store
+	UserStore      limiter.Store
+	AuthStore      limiter.Store
 }
 
-func NewMiddleware(cnf *config.Config, cache Cache, cortexSettings CortexConfig) *Middlewares {
+func NewMiddleware(cnf *config.Config, cache Cache, cortexSettings CortexConfig, ipStore, userStore, authStore limiter.Store) *Middlewares {
 	return &Middlewares{
 		Cnf:            cnf,
 		cache:          cache,
 		cortexSettings: cortexSettings,
+		IPStore:        ipStore,
+		UserStore:      userStore,
+		AuthStore:      authStore,
 	}
 }

--- a/cortex/rest/middlewares/rate_limiter.go
+++ b/cortex/rest/middlewares/rate_limiter.go
@@ -1,0 +1,68 @@
+package middlewares
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ulule/limiter/v3"
+)
+
+func (m *Middlewares) RateLimiter(next http.Handler) http.Handler {
+	// Create limiters for IP and User
+	ipRate := limiter.Rate{
+		Limit:  100,         // 100 requests
+		Period: time.Minute, // per 1 minute
+	}
+	ipLimiter := limiter.New(m.IPStore, ipRate)
+
+	authRate := limiter.Rate{
+		Limit:  5,           // 5 requests
+		Period: time.Minute, // per 1 minute
+	}
+	authLimiter := limiter.New(m.AuthStore, authRate)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Use RemoteAddr for IP-based limiting
+		// NOTE: In production behind a proxy, we should use X-Forwarded-For
+		clientIP := strings.Split(r.RemoteAddr, ":")[0]
+
+		// 1. Global IP Limit
+		context, err := ipLimiter.Get(r.Context(), clientIP)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "Rate limiter error", "error", err)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if context.Reached {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error": "Too many requests from this IP. Please try again later."}`))
+			return
+		}
+
+		// 2. Auth Endpoint Limit (Login/Register)
+		if r.URL.Path == "/api/v1/auth/login" || r.URL.Path == "/api/v1/auth/register" {
+			authCtx, err := authLimiter.Get(r.Context(), clientIP)
+			if err != nil {
+				slog.ErrorContext(r.Context(), "Auth rate limiter error", "error", err)
+			} else if authCtx.Reached {
+				w.WriteHeader(http.StatusTooManyRequests)
+				w.Write([]byte(`{"error": "Too many login/register attempts. Please try again later."}`))
+				return
+			}
+		}
+
+		// 3. User-based Limit (if authenticated)
+		// Assuming AuthenticateJWT sets some user context that we can use
+		// For now, we'll check if there's a user ID in context or header (simplified)
+		// In a real scenario, this middleware should be placed AFTER AuthenticateJWT if we want per-user limiting
+		// But usually global limits are placed early.
+
+		// If we want per-user limiting, we might need to extract the user ID
+		// For now, let's keep it IP-based and Auth-endpoint based as requested for DDoS protection.
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cortex/rest/server.go
+++ b/cortex/rest/server.go
@@ -59,9 +59,9 @@ func NewServeMux(mw *middlewares.Middlewares, handlers *handlers.Handlers) (http
 	swagger.SetupSwagger(mux, swaggerManager)
 
 	// Apply global middlewares to all routes (including swagger)
-	// Order: CORS (outermost) -> Logger -> Recover -> Routes (innermost)
+	// Order: RateLimiter (outermost) -> CORS -> Logger -> Recover -> Routes (innermost)
 	manager := middlewares.NewManager()
-	handler := manager.With(mux, middlewares.CORS, middlewares.Logger, middlewares.Recover)
+	handler := manager.With(mux, mw.RateLimiter, middlewares.CORS, middlewares.Logger, middlewares.Recover)
 
 	return handler, nil
 }

--- a/postal/cmd/rest.go
+++ b/postal/cmd/rest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"postal/config"
 	"postal/post"
@@ -14,6 +15,8 @@ import (
 	"postal/rest/middlewares"
 
 	"github.com/spf13/cobra"
+	"github.com/ulule/limiter/v3"
+	"github.com/ulule/limiter/v3/drivers/store/memory"
 )
 
 var restCmd = &cobra.Command{
@@ -61,7 +64,12 @@ func runRESTServer(cmd *cobra.Command, args []string) error {
 
 	// Initialize middlewares
 	log.Println("🔄 Initializing middlewares...")
-	mw := middlewares.NewMiddlewares(cfg.JWTSecret)
+	// Explicitly set a cleanup interval for the in-memory store
+	ipStore := memory.NewStoreWithOptions(limiter.StoreOptions{
+		Prefix:          "postal:limiter",
+		CleanUpInterval: time.Minute,
+	})
+	mw := middlewares.NewMiddlewares(cfg.JWTSecret, ipStore)
 
 	// Create server
 	log.Println("🔄 Creating HTTP server...")

--- a/postal/go.mod
+++ b/postal/go.mod
@@ -18,8 +18,10 @@ require (
 	github.com/jackc/pgx/v5 v5.4.3 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
+	github.com/ulule/limiter/v3 v3.11.2
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/postal/go.sum
+++ b/postal/go.sum
@@ -20,6 +20,8 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -32,6 +34,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/ulule/limiter/v3 v3.11.2 h1:P4yOrxoEMJbOTfRJR2OzjL90oflzYPPmWg+dvwN2tHA=
+github.com/ulule/limiter/v3 v3.11.2/go.mod h1:QG5GnFOCV+k7lrL5Y8kgEeeflPH3+Cviqlqa8SVSQxI=
 golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=

--- a/postal/rest/middlewares/middleware.go
+++ b/postal/rest/middlewares/middleware.go
@@ -1,11 +1,15 @@
 package middlewares
 
+import "github.com/ulule/limiter/v3"
+
 type Middlewares struct {
 	jwtSecret string
+	IPStore   limiter.Store
 }
 
-func NewMiddlewares(jwtSecret string) *Middlewares {
+func NewMiddlewares(jwtSecret string, ipStore limiter.Store) *Middlewares {
 	return &Middlewares{
 		jwtSecret: jwtSecret,
+		IPStore:   ipStore,
 	}
 }

--- a/postal/rest/middlewares/rate_limiter.go
+++ b/postal/rest/middlewares/rate_limiter.go
@@ -1,0 +1,38 @@
+package middlewares
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ulule/limiter/v3"
+)
+
+func (m *Middlewares) RateLimiter(next http.Handler) http.Handler {
+	// Create limiter for IP with 100 req/min
+	rate := limiter.Rate{
+		Limit:  100,
+		Period: time.Minute,
+	}
+	instance := limiter.New(m.IPStore, rate)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		clientIP := strings.Split(r.RemoteAddr, ":")[0]
+
+		context, err := instance.Get(r.Context(), clientIP)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "Rate limiter error", "error", err)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if context.Reached {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error": "Too many requests. Please try again later."}`))
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/postal/rest/server.go
+++ b/postal/rest/server.go
@@ -59,9 +59,9 @@ func NewServeMux(mw *middlewares.Middlewares, h *handlers.Handlers) (http.Handle
 	swagger.SetupSwagger(mux, swaggerManager)
 
 	// Apply global middlewares to all routes (including swagger)
-	// Order: CORS (outermost) -> Logger -> Recover -> Routes (innermost)
+	// Order: RateLimiter (outermost) -> CORS -> Logger -> Recover -> Routes (innermost)
 	manager := middlewares.NewManager()
-	handler := manager.With(mux, middlewares.CORS, middlewares.Logger, middlewares.Recover)
+	handler := manager.With(mux, mw.RateLimiter, middlewares.CORS, middlewares.Logger, middlewares.Recover)
 
 	return handler, nil
 }


### PR DESCRIPTION
## Changes

# Cortex:
 - Added Redis-backed rate limiting (100 req/min global, 5 req/min for Login/Register).
 
# Postal:
- Added In-memory rate limiting (100 req/min) with automatic 1-minute memory cleanup.

- Integrated ulule/limiter/v3 as the outermost middleware for both services to block DDOS attacks early.